### PR TITLE
Fixed the GitHub repo name in the tips

### DIFF
--- a/web/strings.ts
+++ b/web/strings.ts
@@ -29,7 +29,7 @@ You can connect ${STR.appName} to Beeminder in the Goals tab.
 You can see what hours of the day get the most of a particular tag with the Daily distribution graph.
 You can see a matrix graph of your time in the Graphs tab.
 How do you spend the hours of your day/week/month? Find out in the Graphs tab.
-${STR.appName} is open source! You can find in on GitHub as smittyvb/ttw
+${STR.appName} is open source! You can find in on GitHub as syvb/ttw
 You can easily see all pings over a 30 day time range in the Pings and Graphs tab.
 ${STR.appName} has an API. See the details in Imports/Exports in Settings.
 You can use Tab to use the currently selected tag suggestion.


### PR DESCRIPTION
Fixed the GitHub repo name in the tips: from "smittyvb/ttw" to "syvb/ttw".